### PR TITLE
Fix infinite resource amount calculation

### DIFF
--- a/src/scripts/selection-tool.lua
+++ b/src/scripts/selection-tool.lua
@@ -221,7 +221,7 @@ function selection_tool.process_entity(entity, rate_data, prototypes, research_d
 
           -- account for infinite resource yield
           if resource_prototype.infinite_resource then
-            resource_data.mining_time =  resource_data.mining_time * (resource.amount / 300000)
+            resource_data.mining_time = resource_data.mining_time / (resource.amount / resource_prototype.normal_resource_amount)
           end
 
           -- add required fluid


### PR DESCRIPTION
1) the multiply should be a divide for sure. Tested that much.
2) replacing the constant with the normal_resource_amount from the resource prototype is something i'm not sure about, because the LuaEntity also has "initial_amount", which has the same value and is read write, though changing this initial_amount doesn't affect yield, which makes me think it is the normal_resource_amount from the prototype. It also kind of makes sense. But again, i can't guarantee that it's correct.